### PR TITLE
Added support for Couchbase

### DIFF
--- a/app/generator.js
+++ b/app/generator.js
@@ -38,10 +38,14 @@ const start = (options = defaults) => new Promise((resolve, reject) => {
 });
 
 const validate = (options) => new Promise((resolve, reject) => {
-  if ('json,csv,yml,yaml'.indexOf(options.output) === -1) { // validate output format
+  if ('json,csv,yml,yaml,couchbase'.indexOf(options.output) === -1) { // validate output format
     reject('Unsupported output type');
   } else if (options.archive && path.extname(options.archive) !== '.zip') { // validate archive format
     reject('The archive must be a zip file');
+  } else if (options.destination === 'couchbase' && (!options.server || !options.bucket)) { // validate couchbase
+    reject('For the server and bucket must be specified when outputting to Couchbase');
+  } else if (options.destination === 'couchbase' && options.archive) { // validate couchbase
+    reject('The archive option cannot be used when the output is couchbase');
   } else {
     resolve();
   }

--- a/app/index.js
+++ b/app/index.js
@@ -11,10 +11,13 @@ export default function() {
     .option('-o, --output [value]', 'The output to generate.  Supported formats are: json, csv, yaml', 'json')
     .option('-a, --archive [value]', '(optional) The archive file to generate.  Supported formats are: zip')
     .option('-m, --models [value]', '(optional) A comma-delimited list of models to use', process.cwd())
-    .option('-d, --destination [value]', '(optional) The output destination.  Values can be a "console" or a valid directory path.', process.cwd())
+    .option('-d, --destination [value]', '(optional) The output destination.  Values can be: couchbase, console or a directory path.', process.cwd())
     .option('-f, --format [value]', '(optional) The spacing format to use for JSON and YAML file generation.  Default is 2', 2)
     .option('-n, --number [value]', '(optional) Overrides the number of documents to generate specified by the model.')
     .option('-i, --input [value]', '(optional) A directory of files or file to use as inputs.  Support formats are: json, yaml, csv')
+    .option('-s, --server [address]', 'Couchbase Server address', '127.0.0.1')
+    .option('-b, --bucket [name]', 'Bucket name', 'default')
+    .option('-p, --password [value]', 'Bucket password')
     .parse(process.argv);
 
   // run the program


### PR DESCRIPTION
Closes #2 Added support for generated data to be output to couchbase by using the `-d couchbase -s {{address}} -b {{bucket}} -p {{password}}` command-line options
