### PR TITLE
Added support for output to a Sync Gateway

### DIFF
--- a/app/generator.js
+++ b/app/generator.js
@@ -38,7 +38,7 @@ const start = (options = defaults) => new Promise((resolve, reject) => {
 });
 
 const validate = (options) => new Promise((resolve, reject) => {
-  if ('json,csv,yml,yaml,couchbase'.indexOf(options.output) === -1) { // validate output format
+  if ('json,csv,yml,yaml,couchbase,sync-gateway'.indexOf(options.output) === -1) { // validate output format
     reject('Unsupported output type');
   } else if (options.archive && path.extname(options.archive) !== '.zip') { // validate archive format
     reject('The archive must be a zip file');

--- a/app/index.js
+++ b/app/index.js
@@ -15,9 +15,11 @@ export default function() {
     .option('-f, --format [value]', '(optional) The spacing format to use for JSON and YAML file generation.  Default is 2', 2)
     .option('-n, --number [value]', '(optional) Overrides the number of documents to generate specified by the model.')
     .option('-i, --input [value]', '(optional) A directory of files or file to use as inputs.  Support formats are: json, yaml, csv')
-    .option('-s, --server [address]', 'Couchbase Server address', '127.0.0.1')
+    .option('-s, --server [address]', 'Couchbase Server or Sync-Gateway address', '127.0.0.1')
     .option('-b, --bucket [name]', 'Bucket name', 'default')
     .option('-p, --password [value]', 'Bucket password')
+    .option('-g, --sync_gateway_admin [name]', 'The sync-gateway admin address')
+    .option('-u, --username [name]', 'The sync-gateway username')
     .parse(process.argv);
 
   // run the program


### PR DESCRIPTION
Closes #19, generated output can now be send to a sync gateway.

Usage:

```
data-generator -s {{sync_gateway_server}} -b {{sync_bucket}} -g {{sync_gateway_admin_server}} -u {{sync_gateway_username}} -p {{sync_gateway_password}}
```

The `-g`, `-u` and `-p` command-line switches are optional, as the Sync Gateway can be configured to allow GUEST access.
