### PR TITLE
Bugfix/1.0.0/package json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test:
 coverage test-coverage code-coverage:
 	# if there's no instance source maps files then build the files with source maps
 	@[ -f ./dist/index.js.map ] || (echo "building files with source maps" && make build-source-maps)
-	NODE_ENV="test" nyc --statements 95 --functions 95 --lines 95 --check-coverage -- ava --verbose && exit 0 || exit 1
+	NODE_ENV="test" nyc make test -- --verbose
 
 # These commands only run the report of the code coverage
 report-coverage report-code-coverage:

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-runtime": "^6.18.0",
     "chalk": "^1.1.3",
     "chance": "^1.0.4",
+    "cli-table": "~0.3.1",
     "commander": "^2.9.0",
     "couchbase-promises": "~2.2.0",
     "cson": "^4.0.0",


### PR DESCRIPTION
`cli-table` was never saved as dependency, and trying to let `nyc` check for code coverage broke travis ci results and didn't throw and error on the tests