### PR TITLE
Issue #136: Store documents in Couchbase as JSON data format

### DIFF
--- a/app/output/index.js
+++ b/app/output/index.js
@@ -113,7 +113,7 @@ export default class Output extends Base {
       }
     };
 
-    const parser = parsers[format].stringify;
+    const parser = this.getParser(output, format);
 
     // if the output type is `return` or `console` then this will return the complete
     // data set instead of running them individually
@@ -183,6 +183,19 @@ export default class Output extends Base {
         this.log('error', e);
       }
     });
+  }
+
+  ///# @name getParser
+  ///# @description Returns a parser function for the given output type and format
+  ///# @arg {string} output - Output type
+  ///# @arg {string} format - Output format
+  ///# @returns {function} - Function to format a document
+  getParser(output, format) {
+    if (output === "couchbase" && format === "json") {
+      return (obj) => obj;
+    } else {
+      return parsers[format].stringify;
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "contributors": [
     "Tyler Benton <tjbenton21@gmail.com> (https://github.com/tjbenton)"
   ],
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Command-line utility that generates fake data which can be output as JSON, YAML, CSON, or CSV formats based on models defined in YAML.",
   "scripts": {
     "test": "make test",


### PR DESCRIPTION
Motivation
----------
Currently, when outputting to Couchbase documents are marked with the
string data format.  This can cause compatibility issues with some
Couchbase SDKs, such as .Net.

Modifications
-------------
When outputting to Couchbase with the JSON format, use an output parser
that does nothing and returns in the in-memory object.

Results
-------
JSON is serialized by the Couchbase NodeJS SDK, so it sets the data
format correctly as JSON instead of string.