### PR TITLE
Solves Issue#153

### DIFF
--- a/app/documents.js
+++ b/app/documents.js
@@ -172,7 +172,8 @@ export class Document extends Base {
       const doc = await this.buildDocument(model, i);
       update();
       await delay(0);
-      this.documents[model.name][doc['__key']] = doc;
+      /* eslint no-underscore-dangle: ["error", { "allow": ["__key"] }] */
+      this.documents[model.name][doc.__key] = doc;
     }, this.options.spinners ? 75 : 1000)
       .catch((err) => {
         spinner.fail(err);

--- a/app/documents.js
+++ b/app/documents.js
@@ -97,7 +97,11 @@ export default class Documents extends Base {
       .then(() => {
         let result;
         if (!model.is_dependency) {
-          result = this.emit('data', Object.values(this.documents[model.name]), model);
+          var built_docs = [];
+          for(var key in this.documents[model.name]) {
+            built_docs.push(this.documents[model.name][key]);
+          }
+          result = this.emit('data', built_docs, model);
         }
         // update the total documents number
         this.total += Object.keys(this.documents[model.name]).length;
@@ -183,7 +187,11 @@ export class Document extends Base {
 
     update();
     spinner.stop();
-    return Object.values(this.documents[model.name]);
+    var built_docs = [];
+    for(var key in this.documents[model.name]) {
+      built_docs.push(this.documents[model.name][key]);
+    }
+    return built_docs;
   }
 
   ///# @name updateFakers

--- a/app/documents.js
+++ b/app/documents.js
@@ -97,10 +97,10 @@ export default class Documents extends Base {
       .then(() => {
         let result;
         if (!model.is_dependency) {
-          result = this.emit('data', this.documents[model.name], model);
+          result = this.emit('data', Object.values(this.documents[model.name]), model);
         }
         // update the total documents number
-        this.total += this.documents[model.name].length;
+        this.total += Object.keys(this.documents[model.name]).length;
         model.complete = true;
         this.emit('run');
         return result;
@@ -138,7 +138,7 @@ export class Document extends Base {
   ///# @returns {array} - The array of documents that were generated
   async build(model) {
     if (!this.documents[model.name]) {
-      this.documents[model.name] = [];
+      this.documents[model.name] = {};
     }
 
     this.updateFakers(model.seed);
@@ -150,7 +150,7 @@ export class Document extends Base {
     const spinner = this.spinner(`Documents ${model.name}`);
     spinner.text = `${model.name}`;
     const update = () => {
-      spinner.text = `${model.name} documents (${this.documents[model.name].length}/${model.data.count})`;
+      spinner.text = `${model.name} documents (${Object.keys(this.documents[model.name]).length}/${model.data.count})`;
     };
 
     // if there is a pre_run function call it
@@ -172,7 +172,7 @@ export class Document extends Base {
       const doc = await this.buildDocument(model, i);
       update();
       await delay(0);
-      this.documents[model.name].push(doc);
+      this.documents[model.name][doc.__key] = doc;
     }, this.options.spinners ? 75 : 1000)
       .catch((err) => {
         spinner.fail(err);
@@ -182,7 +182,7 @@ export class Document extends Base {
 
     update();
     spinner.stop();
-    return this.documents[model.name];
+    return Object.values(this.documents[model.name]);
   }
 
   ///# @name updateFakers

--- a/app/documents.js
+++ b/app/documents.js
@@ -98,8 +98,10 @@ export default class Documents extends Base {
         let result;
         if (!model.is_dependency) {
           var built_docs = [];
-          for(var key in this.documents[model.name]) {
-            built_docs.push(this.documents[model.name][key]);
+          for (var key in this.documents[model.name]) {
+            if (key !== '') {
+              built_docs.push(this.documents[model.name][key]);
+            }
           }
           result = this.emit('data', built_docs, model);
         }
@@ -188,8 +190,10 @@ export class Document extends Base {
     update();
     spinner.stop();
     var built_docs = [];
-    for(var key in this.documents[model.name]) {
-      built_docs.push(this.documents[model.name][key]);
+    for (var key in this.documents[model.name]) {
+      if (key !== '') {
+        built_docs.push(this.documents[model.name][key]);
+      }
     }
     return built_docs;
   }

--- a/app/documents.js
+++ b/app/documents.js
@@ -172,7 +172,7 @@ export class Document extends Base {
       const doc = await this.buildDocument(model, i);
       update();
       await delay(0);
-      this.documents[model.name][doc.__key] = doc;
+      this.documents[model.name][doc['__key']] = doc;
     }, this.options.spinners ? 75 : 1000)
       .catch((err) => {
         spinner.fail(err);

--- a/app/documents.js
+++ b/app/documents.js
@@ -178,8 +178,8 @@ export class Document extends Base {
       const doc = await this.buildDocument(model, i);
       update();
       await delay(0);
-      /* eslint no-underscore-dangle: ["error", { "allow": ["__key"] }] */
-      this.documents[model.name][doc.__key] = doc;
+      /* eslint no-underscore-dangle: ["error", { "allow": ["__name", "__key"] }] */
+      this.documents[model.name][doc.__name + doc.__key] = doc;
     }, this.options.spinners ? 75 : 1000)
       .catch((err) => {
         spinner.fail(err);


### PR DESCRIPTION
As explained in Issue #153, there is an issue when two documents are generated with the same key.

I modified the code in documents.js to use a map instead of an array to keep track of the built documents. This map is from doc key to document, so documents clobber each other if they end up with the same id. This should solve the problem for everything downstream, no matter which output function is used.

Switching to a map was more efficient than doing linear time array contains logic after each document was generated.