### PR TITLE
fixed a couple issues with gulp

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -17,12 +17,13 @@ gulp.task('build', () => {
 
   return gulp
     .src(packages, { base })
+    .pipe($.sourcemaps.init())
     .pipe($.plumber({
       errorHandler (err) {
         $.util.log(err.stack)
       },
     }))
-    .pipe($.changed('dist', {
+    .pipe($.changed(base, {
       transformPath: swapSrcWithDist,
     }))
     .pipe(through.obj((file, enc, callback) => {
@@ -36,6 +37,7 @@ gulp.task('build', () => {
       file.path = path.resolve(file.base, swapSrcWithDist(file.relative))
       callback(null, file)
     }))
+    .pipe($.sourcemaps.write('.'))
     .pipe(gulp.dest(base))
 })
 

--- a/package.json
+++ b/package.json
@@ -48,11 +48,13 @@
     "eslint-plugin-import": "~2.8.0",
     "flow-bin": "^0.63.1",
     "flow-typed": "2.2.3",
+    "gulp": "github:gulpjs/gulp#4.0",
     "gulp-babel": "~7.0.0",
     "gulp-changed": "~3.2.0",
     "gulp-cli": "~2.0.0",
     "gulp-load-plugins": "~1.5.0",
     "gulp-plumber": "~1.2.0",
+    "gulp-sourcemaps": "~1.12.1",
     "gulp-util": "~3.0.8",
     "gulp-watch": "~5.0.0",
     "husky": "~0.14.3",
@@ -72,7 +74,5 @@
     "*.md": ["prettier --parser markdown --single-quote --write", "git add"],
     "*.json": ["prettier --parser json --write", "git add"]
   },
-  "dependencies": {
-    "gulp": "github:gulpjs/gulp#4.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
  - Moves gulp to be a dev dependency
  - Fixed issue with `gulp-changed` so now it only compiles files that have actually changed instead of all the files
  - Added sourcemaps so that we can see where errors happen, also so that code coverage tool uses the src files not the dist